### PR TITLE
Specify server port as constant & output value to console

### DIFF
--- a/rfbserver.js
+++ b/rfbserver.js
@@ -192,4 +192,6 @@ RfbServer.prototype.expectMessage = function()
 var s = net.createServer(function(conn) {
     var rfbserv = new RfbServer(conn);
 });
-s.listen(RFB_PORT);
+s.listen(RFB_PORT, function () {
+    console.log('Server listening on port: ' + s.address().port);
+});


### PR DESCRIPTION
Improves handling of port number by making it a constant and provides feedback to the user as to which port to connect to for access.
